### PR TITLE
Please include cstdint for uint8_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ set(EMBED_HEADER_FILE [=[
 #include <stdexcept>
 #include <sstream>
 #include <functional>
+#include <cstdint>
 
 #ifndef __cpp_constexpr_dynamic_alloc
 #   error "battery::embed requires C++20"


### PR DESCRIPTION
Hi. What a nice script! 

Since gcc 13, gcc requires `cstdint` to use uint8_t.
Please include `cstdint` in `EMBED_HEADER_FILE`.
