### PR TITLE
include unordered_map in embed_source_file_template.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(EMBED_MASTER_SOURCE_FILE [==[
 #include <fstream>
 #include <mutex>
 #include <optional>
+#include <unordered_map>
 
 namespace b {
     


### PR DESCRIPTION
On apple-clang, there is a compilation error as followings:

```
build/Release/build/embed/embed_impl.cpp:30:17: error: no template named 'unordered_map' in namespace 'std'
    static std::unordered_map<std::string,FileData> embeddedFiles;
           ~~~~~^
```

It seems to be caused by lack of unordered_map in embed_source_file_template.cpp.
This PR try to fix it.
